### PR TITLE
refactor: Remove unused TAGInfo import and clean up TechPill component

### DIFF
--- a/src/components/TechPill.astro
+++ b/src/components/TechPill.astro
@@ -1,6 +1,5 @@
 ---
-import { type TAGInfo } from "@/tags";
-import { TAGS, getTechInfo } from "@/tags";
+import { getTechInfo } from "@/tags";
 
 interface Props {
     tech: string;

--- a/src/components/screens/ListWriteups.astro
+++ b/src/components/screens/ListWriteups.astro
@@ -55,13 +55,13 @@ const t = tcommons(locale);
         <div
             class="mb-6 flex flex-wrap gap-2 justify-center">
              {buttonsFilter.map((label) => {
-                const translatedLabel = t(`writeups-${label.label.toLowerCase()}`);
+                const translatedLabel = t(`writeups-${label.label.toLowerCase()}`) ?? "Search...";
                 return (
                 <button 
                     data-filter={label.label}
                     class={`filterButton py-1 rounded-full font-bold border-2 w-28 items-center transition-colors ${label.color} ${label.colorHover}`}
                 >
-                    {translatedLabel.charAt(0).toUpperCase() + translatedLabel.slice(1)}
+                    {(translatedLabel.at(0) as string).toUpperCase() + translatedLabel.slice(1)}
                 </button>
                 );
             })}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -6,9 +6,6 @@ import { TAGS } from "./tags";
 type TagNames = (typeof TAGS)[keyof typeof TAGS]["name"];
 // "react" | "vue" | "svelte"
 
-const TECH_KEYS = Object.values(TAGS).map((t) => t.name) as TagNames[];
-
-
 const writeups = defineCollection({
     loader: glob({
         pattern: ["**/*.md", "!dev-*"]


### PR DESCRIPTION
fix: Provide default search label for writeup filter buttons
chore: Remove redundant TECH_KEYS definition in content configuration